### PR TITLE
Fix lint found in melpa PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,12 @@ INIT_PACKAGES="(progn \
 all: compile package-lint clean-elc
 
 package-lint:
-	${EMACS} -Q --eval ${INIT_PACKAGES} --eval '(setq package-lint-main-file "lisp/daml-mode.el")' -batch -f package-lint-batch-and-exit lisp/daml-mode.el
+	${EMACS} -Q --eval ${INIT_PACKAGES} --eval '(setq package-lint-main-file "lisp/daml-mode.el")' -batch -f package-lint-batch-and-exit lisp/daml-mode.el lisp/daml-lsp.el
 
 compile: clean-elc
-	${EMACS} -Q -eval ${INIT_PACKAGES} -L . -batch -f batch-byte-compile lisp/daml-mode.el
+	${EMACS} -Q -eval ${INIT_PACKAGES} -L . -batch -f batch-byte-compile lisp/daml-mode.el lisp/daml-lsp.el
 
 clean-elc:
-	rm -f lisp/daml-mode.elc
+	rm -f lisp/daml-mode.elc lisp/daml-lsp.elc
 
 .PHONY: all compile clean-elc package-lint

--- a/lisp/daml-lsp.el
+++ b/lisp/daml-lsp.el
@@ -1,6 +1,7 @@
 ;;; daml-lsp.el --- LSP client definition for daml
 
 ;; Copyright (C) 2016-2022 Bártfai Tamás
+;; SPDX-License-Identifier: GPL-3.0-or-later
 
 ;;; Commentary:
 

--- a/lisp/daml-lsp.el
+++ b/lisp/daml-lsp.el
@@ -28,6 +28,7 @@
 (add-hook 'kill-buffer-hook #'lsp-daml--virtualResource-kill-hook)
 
 (defun lsp-daml--virtualResource-kill-hook ()
+  "Run when buffer closed to free up LSP resources."
   (when (string-prefix-p "*daml-script " (buffer-name))
 
     (message "lsp-daml--virtualResource-kill-hook")
@@ -41,10 +42,11 @@
                    :text ""))))))
 
 (defun lsp-daml--script-result-buffer-name (script-uri)
+  "Generate a name for result buffer from running daml script SCRIPT-URI."
   (format "*daml-script %s" (url-unhex-string script-uri)))
 
 (lsp-defun lsp-daml--show-resource ((&Command :arguments?))
-  "Execute the show daml script action"
+  "Execute the show daml script action."
   (interactive)
   (let* ((script-uri (elt arguments? 1))
          (result-buf-name (lsp-daml--script-result-buffer-name script-uri)))
@@ -68,14 +70,17 @@
                (DAMLVirtualResourceNote (:uri :note) nil))
 
 (defun lsp-daml--virtualResource-note (workspace params)
+  "Display a virtual resource note with PARAMS.  WORKSPACE is ignored."
   (-let [(&DAMLVirtualResourceNote :uri :note) params]
     (lsp-daml--display-virtualResource uri note)))
 
 (defun lsp-daml--virtualResource-change (workspace params)
+  "Display a virtual resource change with PARAMS.  WORKSPACE is ignored."
   (-let [(&DAMLVirtualResourceChange :uri :contents) params]
     (lsp-daml--display-virtualResource uri contents)))
 
 (defun lsp-daml--display-virtualResource (uri contents)
+  "Display virtual resource info for URI and CONTENTS."
   (let* ((result-buffer-name (lsp-daml--script-result-buffer-name uri))
          (dom (with-temp-buffer
                 (insert contents)

--- a/lisp/daml-mode.el
+++ b/lisp/daml-mode.el
@@ -1,6 +1,7 @@
 ;;; daml-mode.el --- Emacs mode for daml
 
 ;; Copyright (C) 2016-2022 Bártfai Tamás
+;; SPDX-License-Identifier: GPL-3.0-or-later
 
 ;; Author: Joseph Collard
 ;; Package-Requires: ((haskell-mode "16.1") (lsp-mode "7.0") (emacs "25.1"))

--- a/lisp/daml-mode.el
+++ b/lisp/daml-mode.el
@@ -24,8 +24,8 @@
     "controller" "can" "nonconsuming" "with" "mwith"
     "choice" "interface" "key" "maintainer" "exception" "for"
     "viewtype" "magreement" "preconsuming" "postconsuming" "message")
-  "Identifiers treated as reserved keywords in daml and are not
-keywords for Haskell."
+  "Identifiers treated as reserved keywords in daml.
+They are not keywords for Haskell."
   :group 'daml
   :type '(repeat string))
 
@@ -34,8 +34,8 @@ keywords for Haskell."
  (cl-remove-duplicates (append haskell-font-lock-keywords daml-font-lock-keywords)))
 
 (defun daml-font-lock-keywords ()
-  "Generate font lock keywords for daml. Mostly haskell, with some
-daml specific syntax."
+  "Generate font lock keywords for daml.
+Mostly haskell, with some daml specific syntax."
   (append (haskell-font-lock-keywords)
           `(("\\<\\(submit\\|submitMustFail\\|fetch\\|exercise\\|create\\|test\\)\\>"
              0 font-lock-function-name-face)


### PR DESCRIPTION
I'm attempting to [add this package to Melpa](https://github.com/melpa/melpa/pull/8764). There are a few linting steps to be carried out, as documented in the PR's template description and [the CONTRIBUTING doc](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org).

**This PR addresses some of the problems found:**

- Add _daml-lsp.el_ to the `package-lint` and `compile` targets in the Makefile so warnings are picked up from them.
- Add formal license references to the elisp file headers.
- Add / format some doc strings

**The following problems remain ([see output here](https://github.com/melpa/melpa/pull/8764#issuecomment-1741876761)) as I'm not sure how to fix them:**

- If you run `package-lint-current-buffer` on either of the files, you get "file not found errors". (Ignoring since running it programmatically with through `make package-lint` works fine.
- package-lint gives '"lsp-daml--..." doesn't start with package's prefix "daml"' warnings. (Ignoring because this seems to be a lsp client mode naming convention.)
- Byte-compiling _daml-lsp.el_ generates warnings around the `lsp-interface` function: "attempt to let-bind constant" and "reference to free variable". I don't see this warning when compiling uses of `lsp-interface` in the lsp client modes built in to the lsp-mode distribution (e.g. Clojure, PHP).