### PR TITLE
Improve package description

### DIFF
--- a/daml-mode.el
+++ b/daml-mode.el
@@ -1,4 +1,4 @@
-;;; daml-mode.el --- Emacs mode for daml             -*- lexical-binding: t; -*-
+;;; daml-mode.el --- Major mode for daml             -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2016-2022 Bártfai Tamás
 ;; SPDX-License-Identifier: GPL-3.0-or-later


### PR DESCRIPTION
"Emacs" is usually redundant in the description of an elisp package, and it's useful to highlight that this is a major mode.